### PR TITLE
add in-memory fs for tests

### DIFF
--- a/lib/memory-fs.ts
+++ b/lib/memory-fs.ts
@@ -1,0 +1,37 @@
+import fs from "fs";
+import path from "path";
+
+type MountOpts = {
+  dest?: string;
+  recursively?: boolean;
+};
+
+export function mountDirectory(volume: any, src: string, opts: MountOpts = {}) {
+  const dest = opts.dest || src;
+  const recursively = opts.recursively || false;
+
+  volume.mkdirpSync(dest);
+  for (const file of fs.readdirSync(src)) {
+    const filePath = path.join(src, file);
+
+    if (fs.statSync(filePath).isFile()) {
+      const buf = fs.readFileSync(filePath);
+      volume.writeFileSync(path.join(dest, file), buf);
+    } else if (recursively && fs.statSync(filePath).isDirectory()) {
+      mountDirectory(volume, filePath, {
+        dest: path.join(dest, file),
+        recursively: true
+      });
+    }
+  }
+}
+
+export function mountFile(volume: any, src: string, dest?: string) {
+  dest = dest ? dest : src;
+  const destDir = path.parse(dest).dir;
+
+  volume.mkdirpSync(destDir);
+
+  const buf = fs.readFileSync(src);
+  volume.writeFileSync(dest, buf);
+}

--- a/lib/reader/utils.ts
+++ b/lib/reader/utils.ts
@@ -15,6 +15,12 @@ export function copyFileAsync(src: string, dst: string): Promise<any> {
 }
 
 export function gunzipInMemory(fileName: string): Promise<void> {
+  if (!fileExists(fileName)) {
+    throw new Error(
+        'Invalid File Doesnt Exist'
+    );
+  }
+  
   return new Promise(async (resolve, reject) => {
     try {
       const src = fs.createReadStream(fileName);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "ableton-parser",
+  "name": "als-parser",
   "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
@@ -599,6 +599,12 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
     },
+    "fast-extend": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/fast-extend/-/fast-extend-1.0.2.tgz",
+      "integrity": "sha512-XXA9RmlPatkFKUzqVZAFth18R4Wo+Xug/S+C7YlYA3xrXwfPlW3dqNwOb4hvQo7wZJ2cNDYhrYuPzVOfHy5/uQ==",
+      "dev": true
+    },
     "file-type": {
       "version": "13.0.3",
       "resolved": "https://registry.npmjs.org/file-type/-/file-type-13.0.3.tgz",
@@ -663,6 +669,12 @@
         "jsonfile": "^4.0.0",
         "universalify": "^0.1.0"
       }
+    },
+    "fs-monkey": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/fs-monkey/-/fs-monkey-0.3.3.tgz",
+      "integrity": "sha512-FNUvuTAJ3CqCQb5ELn+qCbGR/Zllhf2HtwsdAtBi59s1WeCjKMT81fHcSu7dwIskqGVK+MmOrb7VOBlq3/SItw==",
+      "dev": true
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -1082,6 +1094,16 @@
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.5.tgz",
       "integrity": "sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g==",
       "dev": true
+    },
+    "memfs": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.0.4.tgz",
+      "integrity": "sha512-OcZEzwX9E5AoY8SXjuAvw0DbIAYwUzV/I236I8Pqvrlv7sL/Y0E9aRCon05DhaV8pg1b32uxj76RgW0s5xjHBA==",
+      "dev": true,
+      "requires": {
+        "fast-extend": "1.0.2",
+        "fs-monkey": "0.3.3"
+      }
     },
     "merge-source-map": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,8 @@
     "chai": "4.2.0",
     "chai-as-promised": "7.1.1",
     "codecov": "3.6.1",
+    "fs-monkey": "^0.3.3",
+    "memfs": "^3.0.4",
     "mocha": "6.2.2",
     "nyc": "14.1.1",
     "ts-node": "8.5.2",

--- a/test/parser-test.ts
+++ b/test/parser-test.ts
@@ -1,11 +1,14 @@
-import assert from "mocha";
+import fs from "fs";
+import path from "path";
 import chai from "chai";
 import chaiAsPromised from "chai-as-promised";
-import { parseFile } from "../lib/index";
-import { loadXml } from "../lib/reader/xml";
 import { copySync, remove } from "fs-extra";
-import { fileExists } from "../lib/reader/utils";
-import path from "path";
+import { Volume } from "memfs";
+import { patchFs } from "fs-monkey";
+
+import { parseFile } from "../lib";
+import { loadXml } from "../lib/reader/xml";
+import { copyFileAsync } from "../lib/reader/utils";
 
 chai.use(chaiAsPromised);
 chai.should();
@@ -24,67 +27,123 @@ const sampleXml = "a.xml";
 
 // Resource List
 const resources = [
-  '/private/tmp/com.ununu.als-parser/a/d/drum.aif',
-  '/private/tmp/com.ununu.als-parser/a/d/audio.aif',
-  '/Users/ama/Downloads/Reverb Default.adv',
-  '/Users/mak/Library/Application Support/Ableton/Live 10 Core Library/Devices/Audio Effects/Simple Delay/Dotted Eighth Note.adv'
+  "/private/tmp/com.ununu.als-parser/a/d/drum.aif",
+  "/private/tmp/com.ununu.als-parser/a/d/audio.aif",
+  "/Users/ama/Downloads/Reverb Default.adv",
+  "/Users/mak/Library/Application Support/Ableton/Live 10 Core Library/Devices/Audio Effects/Simple Delay/Dotted Eighth Note.adv"
 ];
 
 const modifiedResource = [
-  '/private/tmp/com.ununu.als-parser/b/d/drum.aif',
-  '/private/tmp/com.ununu.als-parser/b/d/audio.aif',
-  '/Users/ama/Downloads/Reverb Default.adv',
-  '/Users/mak/Library/Application Support/Ableton/Live 10 Core Library/Devices/Audio Effects/Simple Delay/Dotted Eighth Note.adv'
-]
-describe('Parser', function() {
-    describe ('Parse File', function() {
-        // TODO: Put proper analytics to check how slow?
-        this.slow(100);
-        before(async function() {
-            // Create a copy of the sample files.
-            // This is important as the parser modifies the origional file.
-            copySync(resDir, tmpDir);
-            this.expectedXml = await loadXml(path.join(tmpDir, projectDir, sampleXml));
-        });
+  "/private/tmp/com.ununu.als-parser/b/d/drum.aif",
+  "/private/tmp/com.ununu.als-parser/b/d/audio.aif",
+  "/Users/ama/Downloads/Reverb Default.adv",
+  "/Users/mak/Library/Application Support/Ableton/Live 10 Core Library/Devices/Audio Effects/Simple Delay/Dotted Eighth Note.adv"
+];
 
-        it('Load when als project file is given', async function() {
-            let parser = await parseFile(path.join(tmpDir, projectDir, sampleAls));
-            parser.reader.xmlJs.should.eql(this.expectedXml);
-        });
+function mountDirectory(volume: any, dir: string) {
+  volume.mkdirpSync(dir);
+  for (const file of fs.readdirSync(dir)) {
+    const filePath = path.join(dir, file);
 
-        it('Get tracks count when als project file is given', async function() {
-            let parser = await parseFile(path.join(tmpDir, projectDir, sampleAls));
-            parser.getTracksCount().should.eql({ 
-                AudioTrack: 2, 
-                ReturnTrack: 2 
-            });
-        });
+    if (fs.statSync(filePath).isFile()) {
+      const buf = fs.readFileSync(filePath);
+      volume.writeFileSync(filePath, buf);
+    }
+  }
+}
 
-        after(function() {
-            // Cleanup after test
-            remove(tmpDir);
-        });
+describe("Parser", function() {
+  describe("Parse File", function() {
+    // TODO: Put proper analytics to check how slow?
+    this.slow(100);
+    before(async function() {
+      // Create a copy of the sample files.
+      // This is important as the parser modifies the origional file.
+      copySync(resDir, tmpDir);
+      this.expectedXml = await loadXml(
+        path.join(tmpDir, projectDir, sampleXml)
+      );
     });
-    // TODO: This test is not complete, Check issue #9 for further details
-    describe ('Resource', function() {
-        before(async function() {
-            // Create a copy of the sample files.
-            // This is important as the parser modifies the origional file.
-            copySync(resDir, tmpDir2);
-            this.parserA = await parseFile(path.join(tmpDir2, projectDir, sampleAls));
-        });
-        it('Get the list of resourcefiles when als project file is given', function() {
-            this.parserA.getResourceLocations().should.eql(resources);
-        });
-        it('Change location of all resourcefiles when als project file is given', async function() {
-            let newlocation = "/private/tmp/com.ununu.als-parser/b/d/";
-            this.parserA.changeResourceLocations(newlocation);
-            let modifiedProject = await parseFile(path.join(tmpDir2, projectDir, sampleAls));
-            modifiedProject.getResourceLocations().should.eql(modifiedResource);
-        });
-        after(function() {
-            // Cleanup after test
-            remove(tmpDir2);
-        });
-    })
+
+    it("Load when als project file is given", async function() {
+      let parser = await parseFile(path.join(tmpDir, projectDir, sampleAls));
+      parser.reader.xmlJs.should.eql(this.expectedXml);
+    });
+
+    it("Get tracks count when als project file is given", async function() {
+      let parser = await parseFile(path.join(tmpDir, projectDir, sampleAls));
+      parser.getTracksCount().should.eql({
+        AudioTrack: 2,
+        ReturnTrack: 2
+      });
+    });
+
+    after(function() {
+      // Cleanup after test
+      remove(tmpDir);
+    });
+  });
+
+  describe("Resource", function() {
+    before(function() {
+      this.unpatch = () => {};
+
+      this.drumSample = fs.readFileSync(
+        path.join(__dirname, "res/a/d/drum.aif")
+      );
+      this.audioSample = fs.readFileSync(
+        path.join(__dirname, "res/a/d/audio.aif")
+      );
+      this.projectFile = fs.readFileSync(
+        path.join(__dirname, "res/project/a Project/a.als")
+      );
+    });
+
+    beforeEach(async function() {
+      const tmp = "/private/tmp/com.ununu.als-parser";
+      const mockVolume = new Volume();
+
+      mockVolume.mkdirpSync(`${tmp}/a/d`);
+      mockVolume.mkdirpSync(`${tmp}/b/d`);
+      mockVolume.mkdirpSync(`/foo`);
+
+      mockVolume.writeFileSync(`${tmp}/a/d/audio.aif`, this.audioSample);
+      mockVolume.writeFileSync(`${tmp}/a/d/drum.aif`, this.drumSample);
+
+      mockVolume.writeFileSync(`${tmp}/b/d/audio.aif`, this.audioSample);
+      mockVolume.writeFileSync(`${tmp}/b/d/drum.aif`, this.drumSample);
+
+      mockVolume.writeFileSync("/foo/project.als", this.projectFile);
+
+      /* FIXME: this is a very bad practice – pseudo-mounting some of our
+       * dependencies. however, as xml2js and xmlbuilder are fundamentally
+       * flawed node modules, they load modules during runtime and require
+       * a real-mounted fs
+       */
+      mountDirectory(
+        mockVolume,
+        path.join(__dirname, "../node_modules/xmlbuilder/lib")
+      );
+
+      this.unpatch = patchFs(mockVolume);
+    });
+
+    afterEach(function() {
+      this.unpatch();
+    });
+
+    it("Get the list of resourcefiles when als project file is given", async function() {
+      const parser = await parseFile("/foo/project.als");
+      parser.getResourceLocations().should.eql(resources);
+    });
+    it("Change location of all resourcefiles when als project file is given", async function() {
+      const newLocation = "/private/tmp/com.ununu.als-parser/b/d/";
+
+      const parser = await parseFile("/foo/project.als");
+      parser.changeResourceLocations(newLocation);
+
+      const secondParser = await parseFile(path.join("/foo/project.als"));
+      secondParser.getResourceLocations().should.eql(modifiedResource);
+    });
+  });
 });

--- a/test/reader-test.ts
+++ b/test/reader-test.ts
@@ -1,4 +1,3 @@
-import assert from "mocha";
 import chai from "chai";
 import chaiAsPromised from "chai-as-promised";
 import { Reader, INVALID_FILE } from "../lib/reader/reader";
@@ -6,7 +5,10 @@ import { copyFileAsync, changeExt } from "../lib/reader/utils";
 import { loadXml } from "../lib/reader/xml";
 import { copySync, remove } from "fs-extra";
 import path from "path";
-
+import { Volume } from "memfs";
+import { mountDirectory } from "../lib/memory-fs";
+import { patchFs } from "fs-monkey";
+import fs from 'fs'
 chai.use(chaiAsPromised);
 chai.should();
 const expect = chai.expect;
@@ -14,7 +16,7 @@ const expect = chai.expect;
 // Test resource directory
 const resDir = "./test/res";
 // Tmp directory created as an exact copy of the res directory before test
-const tmpDir = "/private/tmp/com.ununu.als-parser/dir2";
+const tmpDir = "/private/tmp/com.ununu.als-parser";
 const tmpDir2 = "/private/tmp/com.ununu.als-parser/dir3";
 
 const projectDir = "project/a Project/";
@@ -22,62 +24,87 @@ const sampleAls = "a.als";
 const sampleXml = "a.xml";
 const invalid_file = "invalid-file";
 
-describe('Reader', function() {
-    describe ('Load Reader', function() {
-        // TODO: Put proper analytics to check how slow?
-        this.slow(100);
-        before(async function() {
-            // Create a copy of the sample files.
-            // This is important as the parser modifies the origional file.
-            copySync(resDir, tmpDir);
-            this.expectedXml = await loadXml(path.join(tmpDir, projectDir, sampleXml));
-        });
+describe("Reader", function() {
+  describe("Load Reader", function() {
+    // TODO: Put proper analytics to check how slow?
+    this.slow(100);
 
-        it('When the valid gzipped als is given', function(done) {
-            let reader = new Reader(path.join(tmpDir, projectDir, sampleAls));
-            // eql is used instead of equal as the objects are not directly comparable
-            reader.load().should.eventually.eql(this.expectedXml).notify(done);
-        });
+    beforeEach(async function() {
+      const mockVolume = new Volume();
 
-        it('When the invalid file type is given', function(done) {
-            let reader = new Reader(path.join(tmpDir, invalid_file));
-            reader.load().should.eventually.rejectedWith(INVALID_FILE).notify(done);
-        });
+      mountDirectory(mockVolume, path.join(__dirname, "res"), {
+        dest: tmpDir,
+        recursively: true
+      });
 
-        it('When the valid extracted(xml) als is given', function(done) {
-            // Create a copy of the extracted xml as .als
-            let tmpAls = changeExt(path.join(tmpDir, projectDir, sampleXml), '.als');
-            copySync(path.join(tmpDir, projectDir, sampleXml), tmpAls);
-            let reader = new Reader(tmpAls);
-            reader.load().should.eventually.eql(this.expectedXml).notify(done);
-        });
+      /* FIXME: see `parser-test.ts` */
+      mountDirectory(
+        mockVolume,
+        path.join(__dirname, "../node_modules/xmlbuilder/lib")
+      );
 
-        after(function() {
-            // Cleanup after test
-            remove(tmpDir);
-        });
+      this.unpatch = patchFs(mockVolume);
+      this.expectedXml = await loadXml(
+        path.join(tmpDir, projectDir, sampleXml)
+      );
     });
-    describe ('Save Reader', function() {
-        before(async function() {
-            // Create a copy of the sample files.
-            // This is important as the parser modifies the origional file.
-            copySync(resDir, tmpDir2);
-            this.reader = new Reader(path.join(tmpDir2, projectDir, sampleAls));
-            await this.reader.load();
-        });
 
-        it('When a valid als file is given', async function() {
-            let newPath = path.join(tmpDir2, projectDir, 'saved.als');
-            await this.reader.save(newPath);
-            // Check if the saved  als is valid
-            let newReader = new Reader(newPath);
-            await newReader.load();
-            newReader.xmlJs.should.eql(this.reader.xmlJs);
-        });
-
-        after(function() {
-            // Cleanup after test
-            remove(tmpDir2);
-        });
+    afterEach(function() {
+      if (this.unpatch) {
+        this.unpatch();
+      }
     });
+
+    it("When the valid gzipped als is given", function(done) {
+      let reader = new Reader(path.join(tmpDir, projectDir, sampleAls));
+      // eql is used instead of equal as the objects are not directly comparable
+      reader
+        .load()
+        .should.eventually.eql(this.expectedXml)
+        .notify(done);
+    });
+
+    it("When the invalid file type is given", function(done) {
+      let reader = new Reader(path.join(tmpDir, invalid_file));
+      reader
+        .load()
+        .should.eventually.rejectedWith(INVALID_FILE)
+        .notify(done);
+    });
+
+    it("When the valid extracted(xml) als is given", function(done) {
+      // Create a copy of the extracted xml as .als
+      let tmpAls = changeExt(path.join(tmpDir, projectDir, sampleXml), ".als");
+      fs.copyFileSync(path.join(tmpDir, projectDir, sampleXml), tmpAls);
+      let reader = new Reader(tmpAls);
+      reader
+        .load()
+        .should.eventually.eql(this.expectedXml)
+        .notify(done);
+    });
+  });
+
+  describe("Save Reader", function() {
+    before(async function() {
+      // Create a copy of the sample files.
+      // This is important as the parser modifies the origional file.
+      copySync(resDir, tmpDir2);
+      this.reader = new Reader(path.join(tmpDir2, projectDir, sampleAls));
+      await this.reader.load();
+    });
+
+    it("When a valid als file is given", async function() {
+      let newPath = path.join(tmpDir2, projectDir, "saved.als");
+      await this.reader.save(newPath);
+      // Check if the saved  als is valid
+      let newReader = new Reader(newPath);
+      await newReader.load();
+      newReader.xmlJs.should.eql(this.reader.xmlJs);
+    });
+
+    after(function() {
+      // Cleanup after test
+      remove(tmpDir2);
+    });
+  });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -43,7 +43,10 @@
     // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
     // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
-    // "typeRoots": [],                       /* List of folders to include type definitions from. */
+    "typeRoots": [                            /* List of folders to include type definitions from. */
+      "types",
+      "node_modules/@types"
+    ],
     // "types": [],                           /* Type declaration files to be included in compilation. */
     // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
     "esModuleInterop": true,                  /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */

--- a/types/fs-monkey/index.d.ts
+++ b/types/fs-monkey/index.d.ts
@@ -1,0 +1,3 @@
+declare module "fs-monkey" {
+  export function patchFs(fs: any): any;
+}


### PR DESCRIPTION
use `memfs` and `fs-monkey` to monkey-patch the filesystem library and run tests in the memory. closes #12.