### PR TITLE
chore(pkg): file-type provides its own type definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "typescript": "3.6.3"
   },
   "dependencies": {
-    "@types/file-type": "10.9.1",
     "@types/fs-extra": "8.0.1",
     "@types/xml2js": "0.4.5",
     "file-type": "13.0.3",


### PR DESCRIPTION
```
warning ableton-parser > @types/file-type@10.9.1: This is a stub types definition. file-type provides its own type definitions, so you do not need this installed.
```